### PR TITLE
Improve context information at cursor position

### DIFF
--- a/server/services/completion.py
+++ b/server/services/completion.py
@@ -16,10 +16,8 @@ class XmlCompletionService:
     on the current XML context.
     """
 
-    xsd_tree: XsdTree
-
     def __init__(self, xsd_tree: XsdTree):
-        self.xsd_tree = xsd_tree
+        self.xsd_tree: XsdTree = xsd_tree
 
     def get_node_completion(self, context: XmlContext) -> CompletionList:
         """Gets a list of completion items with all the available child tags

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -1,8 +1,27 @@
 """This module provides a service to determine position
 context inside an XML document."""
 
-from typing import Optional
+from typing import Optional, List
 from .xsd.types import XsdTree, XsdNode
+from lxml import etree
+from io import BytesIO
+from pygls.workspace import Document, Position
+
+START_TAG_EVENT = "start"
+END_TAG_EVENT = "end"
+
+
+class XmlElement:
+    tag: str
+    tag_position: Position
+    tag_offset: int
+    element: etree.Element
+
+    def __init__(self, tag: str, line: int, character: int):
+        self.tag = tag
+        self.tag_position = Position(line, character)
+        self.tag_offset = -1
+        self.element
 
 
 class XmlContext:
@@ -16,10 +35,16 @@ class XmlContext:
     node: XsdNode
     is_empty: bool
 
+    is_tag: bool
+    is_attribute: bool
+    is_content: bool
+
     def __init__(self, name: str = None, node: XsdNode = None):
         self.element_name = name
         self.node = node
         self.is_empty = False
+        self.is_tag = False
+        self.is_attribute = False
 
 
 class XmlContextService:
@@ -32,12 +57,12 @@ class XmlContextService:
     def __init__(self, xsd_tree: XsdTree):
         self.xsd_tree = xsd_tree
 
-    def get_xml_context(self, xml_content: str, offset: int) -> XmlContext:
+    def get_xml_context(self, document: Document, position: Position) -> XmlContext:
         """Gets the XML context at a given offset inside the document.
 
         Args:
-            xml_content (str): The XML contents.
-            offset (int): The character offset inside de document.
+            document (Document): The current document.
+            position (Position): The position inside de document.
 
         Returns:
             XmlContext: The resulting context with the current node
@@ -45,11 +70,13 @@ class XmlContextService:
             determined, the default context with no information is returned.
         """
         context = XmlContext()
-        if self.is_empty_content(xml_content):
+        if self.is_empty_content(document):
             context.node = self.xsd_tree.root
             context.is_empty = True
             return context
 
+        xml_content = document.source
+        offset = document.offset_at_position(position)
         current_tag = self.find_current_tag(xml_content, offset)
         if current_tag:
             node = self.xsd_tree.find_node_by_name(current_tag)
@@ -57,16 +84,17 @@ class XmlContextService:
         return context
 
     @staticmethod
-    def is_empty_content(xml_content: str) -> bool:
-        """Determines if the given XML text is an empty document.
+    def is_empty_content(document: Document) -> bool:
+        """Determines if the given XML document is an empty document.
 
         Args:
-            xml_content (str): The XML text.
+            document (Document): The document to check.
 
         Returns:
             bool: True if the document is empty and False otherwise.
         """
-        return not xml_content.strip() or xml_content.replace("<", " ").isspace()
+        xml_content = document.source.strip()
+        return not xml_content or len(xml_content) < 2
 
     @staticmethod
     def find_current_tag(content: str, offset: int) -> Optional[str]:
@@ -102,3 +130,42 @@ class XmlContextService:
             end = len(chunk)
         tag = chunk[0:end]
         return tag
+
+    @staticmethod
+    def is_inside_attr_value(content: str, offset: int) -> bool:
+        tag_start = content.rfind("<", 0, offset)
+        attr_value_start = content.rfind('="', 0, offset)
+        return attr_value_start > tag_start
+
+
+class XmlContextParser:
+
+    _current_element: Optional[XmlElement]
+    _content_lines: List[str]
+    _element_stack: List[XmlElement]
+
+    def __init__(self):
+        self._current_element = None
+        self._content_lines = []
+        self._element_stack = []
+        pass
+
+    def parse(self, xml_content: str, offset: int):
+        self._content_lines = xml_content.split("\n")
+        source = BytesIO(xml_content.encode())
+
+        for event, element in etree.iterparse(source, recover=True):
+            if event == END_TAG_EVENT:
+                character = self._find_tag_start_at_line_number(
+                    xml_content, element.tag, element.sourceline
+                )
+                xml_element = XmlElement(element.tag, element.sourceline, character)
+                xml_element.internal = element
+                self._current_element = xml_element
+            else:
+                print(event)
+
+    def _find_tag_start_at_line_number(self, xml_content: str, tag: str, line_number: int):
+        line = self._content_lines[line_number - 1]
+        start_position = line.find(tag)
+        return start_position

--- a/server/services/language.py
+++ b/server/services/language.py
@@ -59,13 +59,9 @@ class GalaxyToolLanguageService:
 
     def get_completion(self, document: Document, params: CompletionParams) -> CompletionList:
         """Gets completion items depending on the current document context."""
-        xml_content = document.source
-        offset = document.offset_at_position(params.position)
         triggerKind = params.context.triggerKind
-
         if triggerKind == CompletionTriggerKind.TriggerCharacter:
-            offset = offset - 1  # ignore/remove trigger character
-            context = self.xml_context_service.get_xml_context(xml_content, offset)
+            context = self.xml_context_service.get_xml_context(document, params.position)
             if params.context.triggerCharacter == "<":
                 return self.completion_service.get_node_completion(context)
             if params.context.triggerCharacter == " ":

--- a/server/services/xsd/parser.py
+++ b/server/services/xsd/parser.py
@@ -32,28 +32,23 @@ class GalaxyToolXsdParser:
     supported by the XSD specification.
     """
 
-    _root: etree.Element
-    _tree: Optional[XsdTree]
-    _named_type_map: Dict[str, etree.Element]
-    _named_group_map: Dict[str, etree.Element]
-
     def __init__(self, xsd_root: etree.Element):
         """Initializes the parser with the given etree root element.
 
         Args:
             xsd_root (etree.Element): The root element of the XSD.
         """
-        self._root = xsd_root
-        self._tree = None
-        self._named_type_map = {}
-        self._named_group_map = {}
+        self._root: etree.Element = xsd_root
+        self._tree: Optional[XsdTree] = None
+        self._named_type_map: Dict[str, etree.Element] = {}
+        self._named_group_map: Dict[str, etree.Element] = {}
 
     def get_tree(self) -> XsdTree:
         """Builds the tree structure from the root etree.Element if
         it does not exists, or returns it if exists.
 
         Returns:
-            XsdTree: The tree structure with all the relevan
+            XsdTree: The tree structure with all the relevant
             information from the XSD schema.
         """
         if self._tree is None:

--- a/server/services/xsd/types.py
+++ b/server/services/xsd/types.py
@@ -15,11 +15,9 @@ class XsdBase:
     XML nodes and attributes.
     """
 
-    name: str
-
     def __init__(self, name: str, element):
         super(XsdBase, self).__init__()
-        self.name = name
+        self.name: str = name
         self.xsd_element = element
 
     def get_doc(self, lang: str = "en") -> MarkupContent:
@@ -58,10 +56,6 @@ class XsdAttribute(XsdBase):
         XsdBase: Inherits base functionality from XsdBase.
     """
 
-    type_name: str
-    is_required: bool
-    enumeration: List[str]
-
     def __init__(
         self,
         name: str,
@@ -70,9 +64,9 @@ class XsdAttribute(XsdBase):
         is_required: bool = False,
     ):
         super(XsdAttribute, self).__init__(name, element)
-        self.type_name = type_name
-        self.is_required = is_required
-        self.enumeration = []
+        self.type_name: str = type_name
+        self.is_required: bool = is_required
+        self.enumeration: List[str] = []
 
 
 class XsdNode(XsdBase, NodeMixin):
@@ -86,17 +80,12 @@ class XsdNode(XsdBase, NodeMixin):
         NodeMixin: Inherits tree node functionality from NodeMixin.
     """
 
-    min_occurs: int
-    max_occurs: int
-    type_name: str
-    attributes: Dict[str, XsdAttribute]
-
     def __init__(self, name: str, element: etree.Element, parent: NodeMixin = None):
         super(XsdNode, self).__init__(name, element)
-        self.parent = parent
-        self.attributes = {}
-        self.min_occurs = 1  # required by default
-        self.max_occurs = -1  # unbounded by default
+        self.parent: NodeMixin = parent
+        self.attributes: Dict[str, XsdAttribute] = {}
+        self.min_occurs: int = 1  # required by default
+        self.max_occurs: int = -1  # unbounded by default
 
     def render(self) -> str:
         """Gets an ascii representation of this node.
@@ -114,10 +103,8 @@ class XsdTree:
     XSD information for all the elements and attributes.
     """
 
-    root: XsdNode
-
     def __init__(self, root: XsdNode):
-        self.root = root
+        self.root: XsdNode = root
 
     def find_node_by_name(self, name: str) -> XsdNode:
         """Finds node in the tree that matches the given name.

--- a/server/tests/unit/test_completion.py
+++ b/server/tests/unit/test_completion.py
@@ -7,6 +7,7 @@ from ...services.completion import (
     XsdNode,
     XsdAttribute,
 )
+from ...services.context import ContextTokenType
 
 
 @pytest.fixture()
@@ -21,16 +22,19 @@ def fake_tree(mocker: MockerFixture):
 @pytest.fixture()
 def fake_empty_context(fake_tree):
     fake_root = fake_tree.root
-    fake_context = XmlContext(None, fake_root)
-    fake_context.is_empty = True
+    fake_context = XmlContext(is_empty=True)
+    fake_context.node = fake_root
     return fake_context
 
 
 @pytest.fixture()
 def fake_context_on_root_node(fake_tree):
     fake_root = fake_tree.root
-    fake_context = XmlContext(fake_root.name, fake_root)
+    fake_context = XmlContext()
     fake_context.is_empty = False
+    fake_context.token_type = ContextTokenType.TAG
+    fake_context.token_name = fake_root.name
+    fake_context.node = fake_root
     return fake_context
 
 

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -1,13 +1,9 @@
 import pytest
 from pytest_mock import MockerFixture
-
-from ...services.context import (
-    XmlContextService,
-    XmlContext,
-    XmlContextParser,
-)
-
 from pygls.workspace import Document, Position
+
+from ...services.context import XmlContextService, XmlContext, XmlContextParser, ContextTokenType
+
 
 # The content starts at line 1 for convenience
 FAKE_CONTENT = """
@@ -24,15 +20,49 @@ def get_fake_document(content: str):
     return Document(FAKE_DOC_URI, content)
 
 
+def print_context_params(document: Document, position: Position):
+    print(f"Test context at position [line={position.line}, char={position.character}]")
+    print(f"Document:\n{document.source}")
+
+
 class TestXmlContextClass:
-    def test_init_sets_properties(self, mocker: MockerFixture) -> None:
-        expected_name = "test"
-        expected_node = mocker.Mock()
+    def test_init_sets_properties(self) -> None:
+        expected_line_content = "test"
+        expected_position = Position()
 
-        context = XmlContext(expected_name, expected_node)
+        context = XmlContext(document_line=expected_line_content, position=expected_position)
 
-        assert context.token_name == expected_name
-        assert context.node == expected_node
+        assert context.document_line == expected_line_content
+        assert context.target_position == expected_position
+        assert not context.is_empty
+
+    def test_context_with_unknown_token_type_returns_all_false(self) -> None:
+        context = XmlContext(token_type=ContextTokenType.UNKNOWN)
+
+        assert not context.is_tag()
+        assert not context.is_attribute_key()
+        assert not context.is_attribute_value()
+
+    def test_context_with_tag_token_type_returns_is_tag(self) -> None:
+        context = XmlContext(token_type=ContextTokenType.TAG)
+
+        assert context.is_tag()
+        assert not context.is_attribute_key()
+        assert not context.is_attribute_value()
+
+    def test_context_with_attr_key_token_type_returns_is_attr_key(self) -> None:
+        context = XmlContext(token_type=ContextTokenType.ATTRIBUTE_KEY)
+
+        assert not context.is_tag()
+        assert context.is_attribute_key()
+        assert not context.is_attribute_value()
+
+    def test_context_with_attr_value_token_type_returns_is_attr_value(self) -> None:
+        context = XmlContext(token_type=ContextTokenType.ATTRIBUTE_VALUE)
+
+        assert not context.is_tag()
+        assert not context.is_attribute_key()
+        assert context.is_attribute_value()
 
 
 class TestXmlContextServiceClass:
@@ -42,39 +72,6 @@ class TestXmlContextServiceClass:
         service = XmlContextService(expected)
 
         assert service.xsd_tree
-
-    @pytest.mark.parametrize(
-        "document, position, expected",
-        [
-            (FAKE_DOCUMENT, Position(line=1, character=4), "tool"),
-            (FAKE_DOCUMENT, Position(line=1, character=8), "tool"),
-            (FAKE_DOCUMENT, Position(line=2, character=0), "tool"),
-            (FAKE_DOCUMENT, Position(line=3, character=0), "tool"),
-            (FAKE_DOCUMENT, Position(line=3, character=21), "tool"),
-            (FAKE_DOCUMENT, Position(line=4, character=0), "tool"),
-            (FAKE_DOCUMENT, Position(line=2, character=5), "description"),
-            (FAKE_DOCUMENT, Position(line=2, character=17), "description"),
-            (FAKE_DOCUMENT, Position(line=3, character=5), "test"),
-            (FAKE_DOCUMENT, Position(line=3, character=12), "test"),
-            (FAKE_DOCUMENT, Position(line=3, character=17), "test"),
-        ],
-    )
-    def test_get_current_tag_at_position_is_expected(
-        self, document: Document, position: Position, expected: str
-    ) -> None:
-        offset = document.offset_at_position(position)
-
-        actual = XmlContextService.find_current_tag(document.source, offset)
-
-        assert actual == expected
-
-    def test_get_current_tag_returns_none_when_empty_document(self) -> None:
-        xml_content = ""
-        offset = 0
-
-        actual = XmlContextService.find_current_tag(xml_content, offset)
-
-        assert actual is None
 
     def test_get_xml_context_returns_empty_document_context(self, mocker: MockerFixture) -> None:
         xml_content = ""
@@ -99,82 +96,38 @@ class TestXmlContextServiceClass:
         assert context.node
         assert context.token_name == expected_element
 
-    def test_get_xml_context_returns_valid_context_without_node(
-        self, mocker: MockerFixture,
-    ) -> None:
-        xsd_tree_mock = mocker.Mock()
-        xml_content = "content with no tags"
-        position = Position(line=0, character=3)
-        service = XmlContextService(xsd_tree_mock)
-
-        context = service.get_xml_context(Document(FAKE_DOC_URI, xml_content), position)
-
-        assert context
-        assert context.node is None
-        assert context.token_name is None
-
-    @pytest.mark.parametrize(
-        "xml_content, expected",
-        [
-            (get_fake_document(""), True),
-            (get_fake_document("<"), True),
-            (get_fake_document(" "), True),
-            (get_fake_document("   "), True),
-            (get_fake_document("\r\n"), True),
-            (get_fake_document("\r"), True),
-            (get_fake_document(" \r"), True),
-            (get_fake_document("\n"), True),
-            (get_fake_document(" \n"), True),
-            (get_fake_document("<a"), False),
-            (get_fake_document("<test"), False),
-        ],
-    )
-    def test_is_empty_content_returns_empty_document_context(
-        self, xml_content: str, expected: bool
-    ) -> None:
-        actual = XmlContextService.is_empty_content(xml_content)
-
-        assert actual == expected
-
-    @pytest.mark.parametrize(
-        "xml_content, offset, expected",
-        [
-            ("<test", 0, None),
-            ("<test", 1, "test"),
-            ("<test\n", 1, "test"),
-            ("<test ", 1, "test"),
-            ("<test>\n", 6, "test"),
-            ("<test/>\n", 7, None),
-            ("<test><other>\n", 7, "other"),
-            ("<test><other/>\n", 14, "test"),
-            ("<test>\r\n<other/>\n", 17, "test"),
-        ],
-    )
-    def test_find_current_tag_returns_expected_tag(
-        self, xml_content: str, offset: int, expected: str,
-    ) -> None:
-        actual = XmlContextService.find_current_tag(xml_content, offset)
-
-        assert actual == expected
-
 
 class TestXmlContextParserClass:
     @pytest.mark.parametrize(
         "document, position, expected",
         [
-            (FAKE_DOCUMENT, Position(line=1, character=4), "tool"),
+            (FAKE_DOCUMENT, Position(line=1, character=0), None),
+            (FAKE_DOCUMENT, Position(line=1, character=1), "tool"),
+            (FAKE_DOCUMENT, Position(line=1, character=5), "tool"),
+            (FAKE_DOCUMENT, Position(line=1, character=6), "id"),
             (FAKE_DOCUMENT, Position(line=1, character=8), "id"),
+            (FAKE_DOCUMENT, Position(line=1, character=9), None),
             (FAKE_DOCUMENT, Position(line=1, character=10), "test"),
+            (FAKE_DOCUMENT, Position(line=1, character=14), "test"),
+            (FAKE_DOCUMENT, Position(line=1, character=15), None),
             (FAKE_DOCUMENT, Position(line=2, character=5), "description"),
+            (FAKE_DOCUMENT, Position(line=2, character=16), "description"),
             (FAKE_DOCUMENT, Position(line=2, character=17), None),
+            (FAKE_DOCUMENT, Position(line=3, character=4), None),
             (FAKE_DOCUMENT, Position(line=3, character=5), "test"),
-            (FAKE_DOCUMENT, Position(line=3, character=12), "value"),
+            (FAKE_DOCUMENT, Position(line=3, character=9), "test"),
+            (FAKE_DOCUMENT, Position(line=3, character=10), "value"),
+            (FAKE_DOCUMENT, Position(line=3, character=15), "value"),
+            (FAKE_DOCUMENT, Position(line=3, character=16), None),
             (FAKE_DOCUMENT, Position(line=3, character=17), "0"),
+            (FAKE_DOCUMENT, Position(line=3, character=18), "0"),
+            (FAKE_DOCUMENT, Position(line=3, character=19), None),
         ],
     )
     def test_parse_well_formed_xml_return_expected_context_token_name(
         self, document: Document, position: Position, expected: str
     ) -> None:
+        print_context_params(document, position)
         parser = XmlContextParser()
 
         context = parser.parse(document, position)
@@ -184,9 +137,14 @@ class TestXmlContextParserClass:
     @pytest.mark.parametrize(
         "document, position, expected",
         [
-            (get_fake_document('<other id="1"'), Position(line=0, character=2), "other"),
+            (get_fake_document('<other id="1"'), Position(line=0, character=0), None),
+            (get_fake_document('<other id="1"'), Position(line=0, character=1), "other"),
+            (get_fake_document('<other id="1"'), Position(line=0, character=6), "other"),
             (get_fake_document('<other id="1"'), Position(line=0, character=7), "id"),
+            (get_fake_document('<other id="1"'), Position(line=0, character=9), "id"),
             (get_fake_document('<other id="1"'), Position(line=0, character=11), "1"),
+            (get_fake_document('<other id="1"'), Position(line=0, character=12), "1"),
+            (get_fake_document('<other id="1"'), Position(line=0, character=13), None),
             (
                 get_fake_document('<first id="1" test="value">\n    <second'),
                 Position(line=0, character=2),
@@ -232,14 +190,65 @@ class TestXmlContextParserClass:
     def test_parse_incomplete_xml_return_expected_context_token_name(
         self, document: Document, position: Position, expected: str
     ) -> None:
+        print_context_params(document, position)
         parser = XmlContextParser()
 
         context = parser.parse(document, position)
 
         assert context.token_name == expected
 
+    @pytest.mark.parametrize(
+        "document, position, expected",
+        [
+            (get_fake_document(""), Position(line=0, character=0), True),
+            (get_fake_document(""), Position(line=0, character=10), True),
+            (get_fake_document("<"), Position(line=0, character=0), True),
+            (get_fake_document("   "), Position(line=0, character=0), True),
+            (get_fake_document("\n\n"), Position(line=0, character=0), True),
+            (get_fake_document("\n\n"), Position(line=1, character=0), True),
+        ],
+    )
+    def test_parse_empty_xml_return_empty_context(
+        self, document: Document, position: Position, expected: bool
+    ) -> None:
+        print_context_params(document, position)
+        parser = XmlContextParser()
 
-# <tool id="test">
-#     <description/>
-#     <test value="0"/>
-# </tool>'
+        context = parser.parse(document, position)
+
+        assert context.is_empty == expected
+
+    @pytest.mark.parametrize(
+        "document, position, expected",
+        [
+            (
+                get_fake_document("<first><second><third>"),
+                Position(line=0, character=1),
+                ["first"],
+            ),
+            (
+                get_fake_document("<first><second><third>"),
+                Position(line=0, character=8),
+                ["first", "second"],
+            ),
+            (
+                get_fake_document("<first><second><third>"),
+                Position(line=0, character=16),
+                ["first", "second", "third"],
+            ),
+            (
+                get_fake_document("<first><second/><third>"),
+                Position(line=0, character=17),
+                ["first", "third"],
+            ),
+        ],
+    )
+    def test_parse_return_valid_tag_stack_context(
+        self, document: Document, position: Position, expected: bool
+    ) -> None:
+        print_context_params(document, position)
+        parser = XmlContextParser()
+
+        context = parser.parse(document, position)
+
+        assert context.node_stack == expected

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -16,6 +16,10 @@ FAKE_DOC_URI = "file://fake_doc.xml"
 FAKE_DOCUMENT = Document(FAKE_DOC_URI, FAKE_CONTENT)
 
 
+def get_fake_document(content: str):
+    return Document(FAKE_DOC_URI, content)
+
+
 class TestXmlContextClass:
     def test_init_sets_properties(self, mocker: MockerFixture) -> None:
         expected_name = "test"
@@ -70,11 +74,11 @@ class TestXmlContextServiceClass:
 
     def test_get_xml_context_returns_empty_document_context(self, mocker: MockerFixture) -> None:
         xml_content = ""
-        offset = 0
+        position = Position()
         xsd_tree_mock = mocker.Mock()
         service = XmlContextService(xsd_tree_mock)
 
-        context = service.get_xml_context(xml_content, offset)
+        context = service.get_xml_context(Document(FAKE_DOC_URI, xml_content), position)
 
         assert context.is_empty
 
@@ -82,10 +86,10 @@ class TestXmlContextServiceClass:
         xsd_tree_mock = mocker.Mock()
         expected_element = "test"
         xml_content = f"<{expected_element}>"
-        offset = 3
+        position = Position(line=0, character=3)
         service = XmlContextService(xsd_tree_mock)
 
-        context = service.get_xml_context(xml_content, offset)
+        context = service.get_xml_context(Document(FAKE_DOC_URI, xml_content), position)
 
         assert context
         assert context.node
@@ -96,10 +100,10 @@ class TestXmlContextServiceClass:
     ) -> None:
         xsd_tree_mock = mocker.Mock()
         xml_content = "content with no tags"
-        offset = 3
+        position = Position(line=0, character=3)
         service = XmlContextService(xsd_tree_mock)
 
-        context = service.get_xml_context(xml_content, offset)
+        context = service.get_xml_context(Document(FAKE_DOC_URI, xml_content), position)
 
         assert context
         assert context.node is None
@@ -108,17 +112,17 @@ class TestXmlContextServiceClass:
     @pytest.mark.parametrize(
         "xml_content, expected",
         [
-            ("", True),
-            ("<", True),
-            (" ", True),
-            ("   ", True),
-            ("\r\n", True),
-            ("\r", True),
-            (" \r", True),
-            ("\n", True),
-            (" \n", True),
-            ("<a", False),
-            ("<test", False),
+            (get_fake_document(""), True),
+            (get_fake_document("<"), True),
+            (get_fake_document(" "), True),
+            (get_fake_document("   "), True),
+            (get_fake_document("\r\n"), True),
+            (get_fake_document("\r"), True),
+            (get_fake_document(" \r"), True),
+            (get_fake_document("\n"), True),
+            (get_fake_document(" \n"), True),
+            (get_fake_document("<a"), False),
+            (get_fake_document("<test"), False),
         ],
     )
     def test_is_empty_content_returns_empty_document_context(

--- a/server/types.py
+++ b/server/types.py
@@ -12,8 +12,8 @@ class WordLocation:
     """
 
     def __init__(self, word: str, range: Range):
-        self.text = word
-        self.range = range
+        self.text: str = word
+        self.range: Range = range
 
     def __eq__(self, other):
         if isinstance(other, WordLocation):


### PR DESCRIPTION
The previous tag location using a basic string finding solution has been replaced by a SAX parser with tolerance to XML syntax errors.
This new solution provides much more information about the context, i.e. in addition to the current node definition, it provides information about the type of the token under the cursor and the complete node path.

This PR also contains test cases for the new classes and some minor code cleanup.