### PR TITLE
Fixes #3 by using more information about the context

### DIFF
--- a/server/services/completion.py
+++ b/server/services/completion.py
@@ -31,6 +31,9 @@ class XmlCompletionService:
             CompletionList: A list of completion items with the child nodes
             that can be placed under the current node.
         """
+        if context.is_invalid:
+            return CompletionList(is_incomplete=False)
+
         result = []
         if context.is_empty:
             result.append(self._build_node_completion_item(context.node))
@@ -65,8 +68,16 @@ class XmlCompletionService:
             CompletionList: The completion item with the basic information
             about the attributes.
         """
+        if (
+            context.is_empty
+            or context.is_invalid
+            or context.is_node_content
+            or context.is_attribute_value()
+        ):
+            return CompletionList(is_incomplete=False)
+
         result = []
-        if context.node and not context.is_empty:
+        if context.node:
             for attr_name in context.node.attributes:
                 attr = context.node.attributes[attr_name]
                 result.append(self._build_attribute_completion_item(attr))

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -11,7 +11,7 @@ from .xsd.types import XsdTree, XsdNode
 
 
 START_TAG_REGEX = r"<([a-z]+)[ \n]?"
-ATTR_KEY_VALUE_REGEX = r" ([a-z]*)=\"([\w.]*)[\"]?"
+ATTR_KEY_VALUE_REGEX = r" ([a-z_]*)=\"([\w. ]*)[\"]?"
 TAG_GROUP = 1
 ATTR_KEY_GROUP = 1
 ATTR_VALUE_GROUP = 2

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -15,7 +15,7 @@ ATTR_KEY_VALUE_REGEX = r" ([a-z_]*)=\"([\w. ]*)[\"]?"
 TAG_GROUP = 1
 ATTR_KEY_GROUP = 1
 ATTR_VALUE_GROUP = 2
-UNCLOSED_TOKEN = "unclosed token"
+SUPPORTED_RECOVERY_EXCEPTIONS = ["unclosed token", "no element found"]
 
 
 @unique
@@ -250,15 +250,15 @@ class ContextParseErrorHandler(xml.sax.ErrorHandler):
 
     def fatalError(self, exception: xml.sax.SAXParseException):
         position = self.get_position(exception)
-        if exception.getMessage() == UNCLOSED_TOKEN:
-            self._try_process_context_from_unclosed_token(position.character)
+        if exception.getMessage() in SUPPORTED_RECOVERY_EXCEPTIONS:
+            self._try_recover_context_from_exception(position.character)
         else:
             self._context.is_invalid = True
 
     def get_position(self, exception: xml.sax.SAXParseException) -> Position:
         return Position(line=exception.getLineNumber() - 1, character=exception.getColumnNumber())
 
-    def _try_process_context_from_unclosed_token(self, start_offset: int) -> None:
+    def _try_recover_context_from_exception(self, start_offset: int) -> None:
         target_offset = self._context.target_position.character
         self._try_get_tag_context_at_line_position(target_offset)
         self._try_get_attribute_context_at_line_position(target_offset)

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -252,3 +252,95 @@ class TestXmlContextParserClass:
         context = parser.parse(document, position)
 
         assert context.node_stack == expected
+
+    @pytest.mark.parametrize(
+        "document, position, expected",
+        [
+            (
+                get_fake_document(
+                    '<first id="1">\n    <second attr="value">test</second>\n<third'
+                ),
+                Position(line=0, character=1),
+                False,
+            ),
+            (
+                get_fake_document(
+                    '<first id="1">\n    <second attr="value">test</second>\n<third'
+                ),
+                Position(line=0, character=8),
+                False,
+            ),
+            (
+                get_fake_document(
+                    '<first id="1">\n    <second attr="value">test</second>\n<third'
+                ),
+                Position(line=0, character=14),
+                True,
+            ),
+            (
+                get_fake_document(
+                    '<first id="1">\n    <second attr="value">test</second>\n<third'
+                ),
+                Position(line=1, character=0),
+                True,
+            ),
+            (
+                get_fake_document(
+                    '<first id="1">\n    <second attr="value">test</second>\n<third'
+                ),
+                Position(line=1, character=4),
+                True,
+            ),
+            (
+                get_fake_document(
+                    '<first id="1">\n    <second attr="value">test</second>\n<third'
+                ),
+                Position(line=1, character=5),
+                False,
+            ),
+            (
+                get_fake_document(
+                    '<first id="1">\n    <second attr="value">test</second>\n<third'
+                ),
+                Position(line=1, character=6),
+                False,
+            ),
+            (
+                get_fake_document(
+                    '<first id="1">\n    <second attr="value">test</second>\n<third'
+                ),
+                Position(line=1, character=24),
+                False,
+            ),
+            (
+                get_fake_document(
+                    '<first id="1">\n    <second attr="value">test</second>\n<third'
+                ),
+                Position(line=1, character=25),
+                True,
+            ),
+            (
+                get_fake_document(
+                    '<first id="1">\n    <second attr="value">test</second>\n<third'
+                ),
+                Position(line=1, character=29),
+                True,
+            ),
+            (
+                get_fake_document(
+                    '<first id="1">\n    <second attr="value">test</second>\n<third'
+                ),
+                Position(line=1, character=30),
+                False,
+            ),
+        ],
+    )
+    def test_parse_returns_context_with_expected_is_node_content(
+        self, document: Document, position: Position, expected: bool
+    ) -> None:
+        print_context_params(document, position)
+        parser = XmlContextParser()
+
+        context = parser.parse(document, position)
+
+        assert context.is_node_content == expected

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -185,6 +185,31 @@ class TestXmlContextParserClass:
                 Position(line=1, character=5),
                 "second",
             ),
+            (
+                get_fake_document('<first id="one_test">\n    <second'),
+                Position(line=0, character=11),
+                "one_test",
+            ),
+            (
+                get_fake_document('<first id="one_test">\n    <second'),
+                Position(line=0, character=19),
+                "one_test",
+            ),
+            (
+                get_fake_document('<first id="one test">\n    <second'),
+                Position(line=0, character=11),
+                "one test",
+            ),
+            (
+                get_fake_document('<first id="one test">\n    <second'),
+                Position(line=0, character=19),
+                "one test",
+            ),
+            (
+                get_fake_document('<first id="one test'),
+                Position(line=0, character=19),
+                "one test",
+            ),
         ],
     )
     def test_parse_incomplete_xml_return_expected_context_token_name(
@@ -196,6 +221,51 @@ class TestXmlContextParserClass:
         context = parser.parse(document, position)
 
         assert context.token_name == expected
+
+    @pytest.mark.parametrize(
+        "document, position, expected",
+        [
+            (
+                get_fake_document('<first id="1" test="value">\n    <second'),
+                Position(line=0, character=0),
+                ContextTokenType.UNKNOWN,
+            ),
+            (
+                get_fake_document('<first id="1" test="value">\n    <second'),
+                Position(line=0, character=2),
+                ContextTokenType.TAG,
+            ),
+            (
+                get_fake_document('<first id="1" test="value">\n    <second'),
+                Position(line=0, character=8),
+                ContextTokenType.ATTRIBUTE_KEY,
+            ),
+            (
+                get_fake_document('<first id="1" test="value">\n    <second'),
+                Position(line=0, character=11),
+                ContextTokenType.ATTRIBUTE_VALUE,
+            ),
+            (
+                get_fake_document('<first id="one_test">\n    <second'),
+                Position(line=0, character=19),
+                ContextTokenType.ATTRIBUTE_VALUE,
+            ),
+            (
+                get_fake_document('<first id="one test'),
+                Position(line=0, character=19),
+                ContextTokenType.ATTRIBUTE_VALUE,
+            ),
+        ],
+    )
+    def test_parse_incomplete_xml_return_expected_context_token_type(
+        self, document: Document, position: Position, expected: str
+    ) -> None:
+        print_context_params(document, position)
+        parser = XmlContextParser()
+
+        context = parser.parse(document, position)
+
+        assert context.token_type == expected
 
     @pytest.mark.parametrize(
         "document, position, expected",


### PR DESCRIPTION
Some improvements to determine if the cursor is inside an attribute definition or within the content part of a tag. With this information, we can avoid triggering the auto-completion in the wrong places.
Added more tests to check the context information is as expected.