### PR TITLE
Fixes #16 by resolving the correct node definition

### DIFF
--- a/server/tests/unit/test_xsd_parser.py
+++ b/server/tests/unit/test_xsd_parser.py
@@ -191,6 +191,23 @@ class TestXsdParserClass:
 
         assert node.name == expected
 
+    @pytest.mark.parametrize(
+        "stack, expected",
+        [
+            (["testElement"], "testElement",),
+            (["testElement", "firstElement"], "firstElement",),
+            (["testElement", "secondElement"], "secondElement",),
+            (["testElement", "secondElement", "group_elem1"], "group_elem1",),
+            (["testElement", "element_with_group", "group_elem1"], "group_elem1",),
+        ],
+    )
+    def test_tree_find_node_by_stack_returns_expected_node(self, xsd_parser, stack, expected):
+        tree = xsd_parser.get_tree()
+
+        node = tree.find_node_by_stack(stack)
+
+        assert node.name == expected
+
     def test_tree_find_node_by_name_returns_None_when_node_not_found(
         self, xsd_parser,
     ):


### PR DESCRIPTION
* Added a [function](https://github.com/davelopez/galaxy-tools-extension/compare/fix-contex-node?expand=1#diff-81db3ec65dc6328bb030ccf2859f5bfcR125-R144) to resolve the node definition (XSD) using the current path of node names.

* Fixed how the [node stack is calculated](https://github.com/davelopez/galaxy-tools-extension/compare/fix-contex-node?expand=1#diff-fc334655ded569ca2404b0b758a8d677R268-R296) when the XML is broken or incomplete.

* Added some tests for edge cases.