### PR TITLE
Autoclose tags feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ The aim of this project is to implement the [Language Server Protocol](https://m
 This repository contains both the [server](https://github.com/davelopez/galaxy-tools-extension/tree/master/server) implementation in [Python](https://www.python.org/) and the [client](https://github.com/davelopez/galaxy-tools-extension/tree/master/client) implementation of a [Visual Studio Code](https://code.visualstudio.com/) [extension](https://marketplace.visualstudio.com/VSCode) in [Node.js](https://nodejs.org/en/).
 
 ## Features
-![Demo Animation](../assets/features.gif)
 * Basic tag and attribute auto-completion 
 * Documentation on Hover
 * Document validation based on the [Galaxy.xsd](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/xsd/galaxy.xsd)
 * Document auto-formatting
+
+    ![Demo Animation](../assets/features.gif)
+* Tag auto-closing
+
+    ![Demo Animation](../assets/autoCloseTag.gif)
 
 ## Release History
 

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -1,0 +1,7 @@
+'use strict';
+
+export namespace Commands {
+
+    export const AUTO_CLOSE_TAGS = 'galaxytools.completion.autoCloseTags';
+
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -2,8 +2,9 @@
 
 import * as net from "net";
 import * as path from "path";
-import { ExtensionContext, workspace } from "vscode";
+import { ExtensionContext, workspace, TextDocument, Position } from "vscode";
 import { LanguageClient, LanguageClientOptions, ServerOptions } from "vscode-languageclient";
+import { activateTagClosing, TagCloseRequest } from './tagClosing';
 
 let client: LanguageClient;
 
@@ -70,6 +71,14 @@ export function activate(context: ExtensionContext) {
   }
 
   context.subscriptions.push(client.start());
+
+  // Setup auto close tags
+  const tagProvider = (document: TextDocument, position: Position) => {
+    let param = client.code2ProtocolConverter.asTextDocumentPositionParams(document, position);
+    let text = client.sendRequest(TagCloseRequest.type, param);
+    return text;
+  };
+  context.subscriptions.push(activateTagClosing(tagProvider));
 }
 
 export function deactivate(): Thenable<void> {

--- a/client/src/tagClosing.ts
+++ b/client/src/tagClosing.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ * 
+ *  Based on: https://github.com/redhat-developer/vscode-xml/blob/master/src/tagClosing.ts
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import { window, workspace, Disposable, TextDocumentContentChangeEvent, TextDocument, Position, SnippetString, Range } from 'vscode';
+import { RequestType, TextDocumentPositionParams } from "vscode-languageclient";
+import { Commands } from './commands'
+
+export namespace TagCloseRequest {
+    export const type: RequestType<TextDocumentPositionParams, AutoCloseTagResult, any, any> = new RequestType(Commands.AUTO_CLOSE_TAGS);
+}
+
+export interface AutoCloseTagResult {
+    snippet: string,
+    range: Range
+}
+
+export function activateTagClosing(tagProvider: (document: TextDocument, position: Position) => Thenable<AutoCloseTagResult>): Disposable {
+    const TRIGGER_CHARACTERS = ['>', '/'];
+    let disposables: Disposable[] = [];
+    workspace.onDidChangeTextDocument(event => onDidChangeTextDocument(event.document, event.contentChanges), null, disposables);
+
+    let timeout: NodeJS.Timer | undefined = void 0;
+
+    function onDidChangeTextDocument(document: TextDocument, changes: ReadonlyArray<TextDocumentContentChangeEvent>) {
+        let activeDocument = window.activeTextEditor && window.activeTextEditor.document;
+        if (document !== activeDocument || changes.length === 0) {
+            return;
+        }
+        if (typeof timeout !== 'undefined') {
+            clearTimeout(timeout);
+        }
+        let lastChange = changes[changes.length - 1];
+        let lastCharacter = lastChange.text[lastChange.text.length - 1];
+        if (lastChange.rangeLength > 0 || lastChange.text.length > 1 || TRIGGER_CHARACTERS.indexOf(lastCharacter) < 0) {
+            return;
+        }
+        let rangeStart = lastChange.range.start;
+        let version = document.version;
+        timeout = setTimeout(() => {
+            let position = new Position(rangeStart.line, rangeStart.character + lastChange.text.length);
+            tagProvider(document, position).then(result => {
+                if (!result) {
+                    return;
+                }
+                let text = result.snippet;
+                let replaceLocation: Position | Range;
+                let range: Range = result.range;
+                if (range != null) {
+                    // re-create Range
+                    let line = range.start.line;
+                    let character = range.start.character;
+                    let startPosition = new Position(line, character);
+                    line = range.end.line;
+                    character = range.end.character;
+                    let endPosition = new Position(line, character);
+                    replaceLocation = new Range(startPosition, endPosition);
+                }
+                else {
+                    replaceLocation = position;
+                }
+                if (text) {
+                    let activeEditor = window.activeTextEditor;
+                    if (activeEditor) {
+                        let activeDocument = activeEditor.document;
+                        if (document === activeDocument && activeDocument.version === version) {
+                            activeEditor.insertSnippet(new SnippetString(text), replaceLocation);
+                        }
+                    }
+                }
+            }, (reason: any) => {
+                console.log('Close tag request has been cancelled. Reason: ' + reason);
+            });
+            timeout = void 0;
+        }, 100);
+    }
+    return Disposable.from(...disposables);
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,3 +15,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auto-formatting when saving file.
 - Display tag documentation when hovering.
 - Basic tag and attribute auto-completion.
+- Auto-close tags feature.

--- a/server/features.py
+++ b/server/features.py
@@ -1,0 +1,4 @@
+"""This module contains definitions for custom features supported
+   by the Galaxy Tools Language Server."""
+
+AUTO_CLOSE_TAGS = "galaxytools.completion.autoCloseTags"

--- a/server/server.py
+++ b/server/server.py
@@ -2,7 +2,8 @@
 """
 
 from .services.language import GalaxyToolLanguageService
-
+from .features import AUTO_CLOSE_TAGS
+from .types import AutoCloseTagResult
 from typing import Optional, List
 from pygls.server import LanguageServer
 from pygls.features import (
@@ -46,6 +47,15 @@ def completions(server: GalaxyToolsLanguageServer, params: CompletionParams) -> 
     return server.service.get_completion(document, params)
 
 
+@language_server.feature(AUTO_CLOSE_TAGS)
+def auto_close_tag(
+    server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams
+) -> AutoCloseTagResult:
+    """Responds to a close tag request to close the currently opened node."""
+    document = server.workspace.get_document(params.textDocument.uri)
+    return server.service.get_auto_close_tag(document, params)
+
+
 @language_server.feature(HOVER)
 def hover(
     server: GalaxyToolsLanguageServer, params: TextDocumentPositionParams
@@ -59,6 +69,7 @@ def hover(
 def formatting(
     server: GalaxyToolsLanguageServer, params: DocumentFormattingParams
 ) -> List[TextEdit]:
+    """Formats the whole document using the provided parameters"""
     document = server.workspace.get_document(params.textDocument.uri)
     content = document.source
     return server.service.format_document(content, params)

--- a/server/services/completion.py
+++ b/server/services/completion.py
@@ -82,10 +82,18 @@ class XmlCompletionService:
         is_self_closing = trigger_character == "/"
         if is_self_closing:
             start = Position(context.target_position.line, context.target_position.character)
-            end = Position(context.target_position.line, context.target_position.character + 1)
+            end_character = context.target_position.character + 1
+            if (
+                len(context.document_line) > end_character
+                and context.document_line[end_character] == ">"
+            ):
+                end_character = end_character + 1
+            end = Position(context.target_position.line, end_character)
             replace_range = Range(start=start, end=end)
             if not context.is_node_content:
                 snippet = "/>$0"
+        elif context.is_node_content:
+            return None
 
         return AutoCloseTagResult(snippet, replace_range)
 

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -274,7 +274,8 @@ class ContextParseErrorHandler(xml.sax.ErrorHandler):
                 if tag_start <= target_offset <= tag_end:
                     self._context.token_type = ContextTokenType.TAG
                     self._context.token_name = tag
-                    self._context.node_stack.append(tag)
+                    if tag not in self._context.node_stack:
+                        self._context.node_stack.append(tag)
                     raise ContextFoundException()
 
                 if (

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -214,7 +214,7 @@ class ContextBuilderHandler(xml.sax.ContentHandler):
     def _build_context_from_element_line(self, start_position: int, tag: str, attributes):
         target_offset = self._context.target_position.character
         tag_offset = start_position + len(tag)
-        is_on_tag = start_position < target_offset <= tag_offset
+        is_on_tag = start_position <= target_offset <= tag_offset
         if is_on_tag:
             self._context.token_type = ContextTokenType.TAG
             self._context.token_name = tag

--- a/server/services/language.py
+++ b/server/services/language.py
@@ -1,6 +1,6 @@
 from .xsd.service import GalaxyToolXsdService
 from .format import GalaxyToolFormatService
-from .completion import XmlCompletionService
+from .completion import XmlCompletionService, AutoCloseTagResult
 from .context import XmlContextService
 from ..utils.pygls_utils import get_word_at_position
 
@@ -14,6 +14,7 @@ from pygls.types import (
     DocumentFormattingParams,
     Hover,
     Position,
+    TextDocumentPositionParams,
     TextEdit,
 )
 
@@ -66,3 +67,12 @@ class GalaxyToolLanguageService:
                 return self.completion_service.get_node_completion(context)
             if params.context.triggerCharacter == " ":
                 return self.completion_service.get_attribute_completion(context)
+
+    def get_auto_close_tag(
+        self, document: Document, params: TextDocumentPositionParams
+    ) -> AutoCloseTagResult:
+        """Gets the closing result for the currently opened tag in context."""
+        trigger_character = document.lines[params.position.line][params.position.character - 1]
+        position_before_trigger = Position(params.position.line, params.position.character - 1)
+        context = self.xml_context_service.get_xml_context(document, position_before_trigger)
+        return self.completion_service.get_auto_close_tag(context, trigger_character)

--- a/server/tests/unit/test_completion.py
+++ b/server/tests/unit/test_completion.py
@@ -2,6 +2,8 @@ import pytest
 from pytest_mock import MockerFixture
 from ...services.completion import (
     AutoCloseTagResult,
+    Position,
+    Range,
     XmlCompletionService,
     XmlContext,
     XsdTree,
@@ -12,7 +14,7 @@ from ...services.context import ContextTokenType
 
 
 @pytest.fixture()
-def fake_tree(mocker: MockerFixture):
+def fake_tree(mocker: MockerFixture) -> XsdTree:
     fake_root = XsdNode("root", element=mocker.Mock())
     fake_attr = XsdAttribute("attr", element=mocker.Mock())
     fake_root.attributes[fake_attr.name] = fake_attr
@@ -21,7 +23,7 @@ def fake_tree(mocker: MockerFixture):
 
 
 @pytest.fixture()
-def fake_empty_context(fake_tree):
+def fake_empty_context(fake_tree: XsdTree) -> XmlContext:
     fake_root = fake_tree.root
     fake_context = XmlContext(is_empty=True)
     fake_context.node = fake_root
@@ -29,7 +31,16 @@ def fake_empty_context(fake_tree):
 
 
 @pytest.fixture()
-def fake_context_on_root_node(fake_tree):
+def fake_invalid_context(fake_tree: XsdTree) -> XmlContext:
+    fake_root = fake_tree.root
+    fake_context = XmlContext()
+    fake_context.is_invalid = True
+    fake_context.node = fake_root
+    return fake_context
+
+
+@pytest.fixture()
+def fake_context_on_root_node(fake_tree: XsdTree) -> XmlContext:
     fake_root = fake_tree.root
     fake_context = XmlContext()
     fake_context.is_empty = False
@@ -39,15 +50,26 @@ def fake_context_on_root_node(fake_tree):
     return fake_context
 
 
+def get_fake_context_with_line_position(
+    fake_tree: XsdTree, line: str, position: Position
+) -> XmlContext:
+    fake_root = fake_tree.root
+    fake_context = XmlContext()
+    fake_context.document_line = line
+    fake_context.target_position = position
+    fake_context.node = fake_root
+    return fake_context
+
+
 class TestXmlCompletionServiceClass:
-    def test_init_sets_properties(self, fake_tree) -> None:
+    def test_init_sets_properties(self, fake_tree: XsdTree) -> None:
 
         service = XmlCompletionService(fake_tree)
 
         assert service.xsd_tree
 
     def test_return_valid_completion_with_node_context(
-        self, fake_tree, fake_context_on_root_node
+        self, fake_tree: XsdTree, fake_context_on_root_node
     ) -> None:
         service = XmlCompletionService(fake_tree)
 
@@ -57,7 +79,7 @@ class TestXmlCompletionServiceClass:
         assert actual.items[0].label == fake_tree.root.children[0].name
 
     def test_completion_return_root_node_when_empty_context(
-        self, fake_tree, fake_empty_context
+        self, fake_tree: XsdTree, fake_empty_context
     ) -> None:
         service = XmlCompletionService(fake_tree)
 
@@ -66,8 +88,17 @@ class TestXmlCompletionServiceClass:
         assert len(actual.items) == 1
         assert actual.items[0].label == fake_tree.root.name
 
+    def test_returns_empty_completion_when_invalid_context(
+        self, fake_tree: XsdTree, fake_invalid_context
+    ) -> None:
+        service = XmlCompletionService(fake_tree)
+
+        actual = service.get_node_completion(fake_invalid_context)
+
+        assert len(actual.items) == 0
+
     def test_return_empty_attribute_completion_when_empty_context(
-        self, fake_tree, fake_empty_context
+        self, fake_tree: XsdTree, fake_empty_context
     ) -> None:
         service = XmlCompletionService(fake_tree)
 
@@ -76,13 +107,80 @@ class TestXmlCompletionServiceClass:
         assert len(actual.items) == 0
 
     def test_return_valid_attribute_completion_when_node_context(
-        self, fake_tree, fake_context_on_root_node
+        self, fake_tree: XsdTree, fake_context_on_root_node
     ) -> None:
         service = XmlCompletionService(fake_tree)
 
         actual = service.get_attribute_completion(fake_context_on_root_node)
 
         assert len(actual.items) > 0
+
+    @pytest.mark.parametrize(
+        "context_line, position, trigger, expected",
+        [
+            ("<root>", Position(line=0, character=6), ">", "$0</root>"),
+            ("<root/", Position(line=0, character=0), "/", "/>$0"),
+        ],
+    )
+    def test_auto_close_returns_expected_snippet_at_context(
+        self,
+        fake_tree: XsdTree,
+        context_line: str,
+        position: Position,
+        trigger: str,
+        expected: str,
+    ) -> None:
+        service = XmlCompletionService(fake_tree)
+        fake_context = get_fake_context_with_line_position(fake_tree, context_line, position)
+
+        actual = service.get_auto_close_tag(fake_context, trigger)
+
+        assert actual.snippet == expected
+
+    @pytest.mark.parametrize(
+        "context_line, position, trigger, expected",
+        [
+            ("<root>", Position(line=0, character=6), ">", None),
+            (
+                "<root/",
+                Position(line=0, character=5),
+                "/",
+                Range(Position(character=5), Position(character=6)),
+            ),
+            (
+                "<root/>",
+                Position(line=0, character=5),
+                "/",
+                Range(Position(character=5), Position(character=7)),
+            ),
+        ],
+    )
+    def test_auto_close_returns_expected_replace_range_at_context(
+        self,
+        fake_tree: XsdTree,
+        context_line: str,
+        position: Position,
+        trigger: str,
+        expected: str,
+    ) -> None:
+        service = XmlCompletionService(fake_tree)
+        fake_context = get_fake_context_with_line_position(fake_tree, context_line, position)
+
+        actual = service.get_auto_close_tag(fake_context, trigger)
+
+        assert actual.range == expected
+
+    def test_auto_close_returns_none_when_at_node_content(
+        self, fake_tree: XsdTree, fake_context_on_root_node: XmlContext
+    ) -> None:
+        service = XmlCompletionService(fake_tree)
+        trigger = ">"
+        fake_context = fake_context_on_root_node
+        fake_context.is_node_content = True
+
+        actual = service.get_auto_close_tag(fake_context, trigger)
+
+        assert not actual
 
 
 class TestAutoCloseTagResultClass:

--- a/server/tests/unit/test_completion.py
+++ b/server/tests/unit/test_completion.py
@@ -1,6 +1,7 @@
 import pytest
 from pytest_mock import MockerFixture
 from ...services.completion import (
+    AutoCloseTagResult,
     XmlCompletionService,
     XmlContext,
     XsdTree,
@@ -82,3 +83,14 @@ class TestXmlCompletionServiceClass:
         actual = service.get_attribute_completion(fake_context_on_root_node)
 
         assert len(actual.items) > 0
+
+
+class TestAutoCloseTagResultClass:
+    def test_init_sets_properties(self, mocker: MockerFixture) -> None:
+        expected_snippet = "snippet"
+        expected_replace_range = mocker.Mock()
+
+        result = AutoCloseTagResult(expected_snippet, expected_replace_range)
+
+        assert result.snippet == expected_snippet
+        assert result.range == expected_replace_range

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -403,6 +403,11 @@ class TestXmlContextParserClass:
                 Position(line=0, character=30),
                 ["first", "third"],
             ),
+            (
+                get_fake_document('<first attr="value"><third>\n'),
+                Position(line=0, character=26),
+                ["first", "third"],
+            ),
         ],
     )
     def test_parse_return_expected_tag_stack_context(

--- a/server/types.py
+++ b/server/types.py
@@ -19,3 +19,13 @@ class WordLocation:
         if isinstance(other, WordLocation):
             return self.text == other.text and self.range == other.range
         return NotImplemented
+
+
+class AutoCloseTagResult:
+    """Contains the code snippet and the range in the text document that
+    will be returned to the client when a tag auto-close is requested.
+    """
+
+    def __init__(self, snippet: str, replace_range: Range = None):
+        self.snippet = snippet
+        self.range = replace_range


### PR DESCRIPTION
Implementation of the auto-close tag feature.
![autoCloseTag](https://user-images.githubusercontent.com/46503462/93234932-362b4700-f77d-11ea-9d8f-30083e16da77.gif)
The client (Node.js) implementation is based on [this solution](https://github.com/redhat-developer/vscode-xml/blob/master/src/tagClosing.ts) originally from Microsoft HMTL language-features.

Closes #11 