### PR TITLE
Improve hover help

### DIFF
--- a/server/services/context.py
+++ b/server/services/context.py
@@ -273,7 +273,7 @@ class ContextBuilderHandler(xml.sax.ContentHandler):
                     Position(line=self._context.target_position.line, character=attr_value_end),
                 )
                 raise ContextFoundException()
-            accum = attr_value_end
+            accum = attr_value_end + 1  # closing \"
 
 
 class ContextParseErrorHandler(xml.sax.ErrorHandler):

--- a/server/services/language.py
+++ b/server/services/language.py
@@ -40,7 +40,7 @@ class GalaxyToolLanguageService:
     def get_documentation(self, document: Document, position: Position) -> Optional[Hover]:
         """Gets the documentation about the element at the given position."""
         context = self.xml_context_service.get_xml_context(document, position)
-        if context.is_node_content:
+        if context.is_node_content or context.is_attribute_value():
             return None
         documentation = self.xsd_service.get_documentation_for(context)
         return Hover(documentation, context.token_range)

--- a/server/services/xsd/types.py
+++ b/server/services/xsd/types.py
@@ -20,6 +20,9 @@ class XsdBase:
         self.name: str = name
         self.xsd_element = element
 
+    def __repr__(self) -> str:
+        return self.name
+
     def get_doc(self, lang: str = "en") -> MarkupContent:
         """Gets the Markdown documentation associated with this element
         from the XSD schema.

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -480,9 +480,14 @@ class TestXmlContextParserClass:
                 Range(start=Position(line=1, character=14), end=Position(line=1, character=19)),
             ),
             (
-                get_fake_document("<first><second/><third"),
-                Position(line=0, character=10),
-                Range(start=Position(line=0, character=8), end=Position(line=0, character=14)),
+                get_fake_document('<first attr1="value1" attr2="value2">'),
+                Position(line=0, character=24),
+                Range(start=Position(line=0, character=22), end=Position(line=0, character=27)),
+            ),
+            (
+                get_fake_document('<first attr1="value1" attr2="value2">'),
+                Position(line=0, character=30),
+                Range(start=Position(line=0, character=29), end=Position(line=0, character=35)),
             ),
         ],
     )

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -9,6 +9,7 @@ from ...services.context import (
     ContextTokenType,
     XsdTree,
     XsdNode,
+    Range,
 )
 
 
@@ -267,6 +268,16 @@ class TestXmlContextParserClass:
                 Position(line=0, character=19),
                 "one test",
             ),
+            (
+                get_fake_document('<first id="value"><second/></first>'),
+                Position(line=0, character=19),
+                "second",
+            ),
+            (
+                get_fake_document('<first id="value"><second/></first>'),
+                Position(line=0, character=29),
+                "first",
+            ),
         ],
     )
     def test_parse_incomplete_xml_return_expected_context_token_name(
@@ -311,6 +322,21 @@ class TestXmlContextParserClass:
                 get_fake_document('<first id="one test'),
                 Position(line=0, character=19),
                 ContextTokenType.ATTRIBUTE_VALUE,
+            ),
+            (
+                get_fake_document('<first id="value"><second/></first>'),
+                Position(line=0, character=19),
+                ContextTokenType.TAG,
+            ),
+            (
+                get_fake_document('<first id="value"><second/></first>'),
+                Position(line=0, character=29),
+                ContextTokenType.TAG,
+            ),
+            (
+                get_fake_document('<first id="value"><second/></first'),
+                Position(line=0, character=29),
+                ContextTokenType.UNKNOWN,
             ),
         ],
     )
@@ -365,8 +391,28 @@ class TestXmlContextParserClass:
             ),
             (
                 get_fake_document("<first><second/><third>"),
+                Position(line=0, character=8),
+                ["first", "second"],
+            ),
+            (
+                get_fake_document("<first><second/><third>"),
                 Position(line=0, character=17),
                 ["first", "third"],
+            ),
+            (
+                get_fake_document("<first><second></second><third>"),
+                Position(line=0, character=25),
+                ["first", "third"],
+            ),
+            (
+                get_fake_document("<first><second/></first>"),
+                Position(line=0, character=18),
+                ["first"],
+            ),
+            (
+                get_fake_document("<first><second/>\n</first>"),
+                Position(line=1, character=2),
+                ["first"],
             ),
             (
                 get_fake_document('<first><second attr="value"/><third'),
@@ -389,6 +435,66 @@ class TestXmlContextParserClass:
         context = parser.parse(document, position)
 
         assert context.node_stack == expected
+
+    @pytest.mark.parametrize(
+        "document, position, expected",
+        [
+            (
+                get_fake_document("<first><second><third>"),
+                Position(line=0, character=1),
+                Range(start=Position(line=0, character=1), end=Position(line=0, character=6)),
+            ),
+            (
+                get_fake_document("<first><second><third>"),
+                Position(line=0, character=8),
+                Range(start=Position(line=0, character=8), end=Position(line=0, character=14)),
+            ),
+            (
+                get_fake_document("<first><second/><third>"),
+                Position(line=0, character=8),
+                Range(start=Position(line=0, character=8), end=Position(line=0, character=14)),
+            ),
+            (
+                get_fake_document("<first><second/><third>"),
+                Position(line=0, character=17),
+                Range(start=Position(line=0, character=17), end=Position(line=0, character=22)),
+            ),
+            (
+                get_fake_document("<first><second></second><third>"),
+                Position(line=0, character=25),
+                Range(start=Position(line=0, character=25), end=Position(line=0, character=30)),
+            ),
+            (
+                get_fake_document("<first><second/>\n</first>"),
+                Position(line=1, character=2),
+                Range(start=Position(line=1, character=0), end=Position(line=1, character=8)),
+            ),
+            (
+                get_fake_document('<first attr="value"/><third'),
+                Position(line=0, character=8),
+                Range(start=Position(line=0, character=7), end=Position(line=0, character=11)),
+            ),
+            (
+                get_fake_document('<first>\n<second attr="value"/>\n<third'),
+                Position(line=1, character=15),
+                Range(start=Position(line=1, character=14), end=Position(line=1, character=19)),
+            ),
+            (
+                get_fake_document("<first><second/><third"),
+                Position(line=0, character=10),
+                Range(start=Position(line=0, character=8), end=Position(line=0, character=14)),
+            ),
+        ],
+    )
+    def test_parse_return_expected_tag_range_context(
+        self, document: Document, position: Position, expected: bool
+    ) -> None:
+        print_context_params(document, position)
+        parser = XmlContextParser()
+
+        context = parser.parse(document, position)
+
+        assert context.token_range == expected
 
     @pytest.mark.parametrize(
         "document, position, expected",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [flake8]
 max-line-length = 99
+ignore = E203,
+         W503


### PR DESCRIPTION
The documentation retrieval on hover has been improved by using the token information from the context.
- The documentation is now provided for tags and attributes (previously only tags where supported).
- The ``XmlContext.token_range`` has been included to highlight the position of the context token.
- The correct XSD element definition is now associated with the token so the correct documentation is shown (if available).

Included more tests for this functionality.

Closes #8