### PR TITLE
Add first snippet to create a basic tool template

### DIFF
--- a/client/src/snippets.json
+++ b/client/src/snippets.json
@@ -19,5 +19,22 @@
             "</tool>"
         ],
         "description": "Creates a basic Galaxy tool structure"
+    },
+    "Conditional Select": {
+        "prefix": "gx-conditional-select",
+        "body": [
+            "<conditional name=\"$1\">",
+            "    <param name=\"$2\" type=\"select\" label=\"$3\">",
+            "        <option value=\"$4\">TODO: option $4</option>",
+            "        <option value=\"$5\">TODO: option $5</option>",
+            "    </param>",
+            "    <when value=\"$4\">",
+            "        $0",
+            "    </when>",
+            "    <when value=\"$5\">",
+            "    </when>",
+            "</conditional>"
+        ],
+        "description": "Conditional parameter select with two options"
     }
 }

--- a/client/src/snippets.json
+++ b/client/src/snippets.json
@@ -2,11 +2,11 @@
     "Basic Galaxy tool": {
         "prefix": "gx-tool",
         "body": [
-            "<tool id='$1' name='$2' version='0.1.0'>",
+            "<tool id=\"$1\" name=\"$2\" version=\"0.1.0\">",
             "    <requirements>",
             "        $0",
             "    </requirements>",
-            "    <command detect_errors='exit_code'><![CDATA[",
+            "    <command detect_errors=\"exit_code\"><![CDATA[",
             "        TODO: Fill in command template.",
             "    ]]></command>",
             "    <inputs>",

--- a/client/src/snippets.json
+++ b/client/src/snippets.json
@@ -1,6 +1,6 @@
 {
     "Basic Galaxy tool": {
-        "prefix": "gtool",
+        "prefix": "gx-tool",
         "body": [
             "<tool id='$1' name='$2' version='0.1.0'>",
             "    <requirements>",

--- a/client/src/snippets.json
+++ b/client/src/snippets.json
@@ -1,0 +1,23 @@
+{
+    "Basic Galaxy tool": {
+        "prefix": "gtool",
+        "body": [
+            "<tool id='$1' name='$2' version='0.1.0'>",
+            "    <requirements>",
+            "        $0",
+            "    </requirements>",
+            "    <command detect_errors='exit_code'><![CDATA[",
+            "        TODO: Fill in command template.",
+            "    ]]></command>",
+            "    <inputs>",
+            "    </inputs>",
+            "    <outputs>",
+            "    </outputs>",
+            "    <help><![CDATA[",
+            "        TODO: Fill in help.",
+            "    ]]></help>",
+            "</tool>"
+        ],
+        "description": "Creates a basic Galaxy tool structure"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,13 @@
       "type": "object",
       "title": "Galaxy Tools Extension Configuration",
       "properties": {}
-    }
+    },
+    "snippets": [
+      {
+        "language": "xml",
+        "path": "./client/src/snippets.json"
+      }
+    ]
   },
   "main": "./client/out/extension",
   "scripts": {


### PR DESCRIPTION
Configured the VSCode extension to contribute snippets defined in [snippets.json](https://github.com/davelopez/galaxy-tools-extension/compare/snippets?expand=1#diff-663e38ec260b17239e542bd620f28f2e) file.

The ``gtool`` snippet creates the basic structure of a Galaxy Tool.
![snippets](https://user-images.githubusercontent.com/46503462/93528567-d084b980-f93a-11ea-97b4-31aa022af168.gif)

More snippets can be contributed to this file following the snippets syntax [here](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax)