### PR TITLE
Autocomplete attribute values with enumeration restrictions

### DIFF
--- a/server/services/completion.py
+++ b/server/services/completion.py
@@ -36,6 +36,7 @@ class XmlCompletionService:
         elif triggerKind == CompletionTriggerKind.Invoked:
             if xml_context.is_attribute_value():
                 return self.get_attribute_value_completion(xml_context)
+        return CompletionList(items=[], is_incomplete=False)
 
     def get_node_completion(self, context: XmlContext) -> CompletionList:
         """Gets a list of completion items with all the available child tags
@@ -88,6 +89,15 @@ class XmlCompletionService:
         return CompletionList(items=result, is_incomplete=False)
 
     def get_attribute_value_completion(self, context: XmlContext) -> CompletionList:
+        """Gets a list of possible values for a anumeration restricted attribute if exists.
+
+        Args:
+            context (XmlContext): The XML context at an attribute value position.
+
+        Returns:
+            CompletionList: The list of possible values of the attribute if it has an enumeration
+            restriction.
+        """
         attribute: XsdAttribute = context.node.attributes.get(context.attr_name)
         if attribute and attribute.enumeration:
             result = [
@@ -148,7 +158,7 @@ class XmlCompletionService:
         """
         return CompletionItem(
             attr.name,
-            CompletionItemKind.Value,
+            CompletionItemKind.Variable,
             documentation=attr.get_doc(),
             insert_text=f'{attr.name}="$1"',
             insert_text_format=InsertTextFormat.Snippet,

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -53,6 +53,7 @@ class XmlContext:
         self.token_name = token_name
         self.token_type = token_type
         self.token_range: Range = None
+        self.attr_name = None
         self.node: Optional[XsdNode] = None
         self.is_node_content: bool = False
         self.node_stack: List[str] = []
@@ -268,6 +269,7 @@ class ContextBuilderHandler(xml.sax.ContentHandler):
             if is_on_attr_value:
                 self._context.token_type = ContextTokenType.ATTRIBUTE_VALUE
                 self._context.token_name = attr_value
+                self._context.attr_name = attr_name
                 self._context.token_range = Range(
                     Position(line=self._context.target_position.line, character=attr_value_start),
                     Position(line=self._context.target_position.line, character=attr_value_end),
@@ -355,6 +357,7 @@ class ContextParseErrorHandler(xml.sax.ErrorHandler):
                 if match.start(ATTR_VALUE_GROUP) <= target_offset <= match.end(ATTR_VALUE_GROUP):
                     self._context.token_type = ContextTokenType.ATTRIBUTE_VALUE
                     self._context.token_name = match.group(ATTR_VALUE_GROUP)
+                    self._context.attr_name = match.group(ATTR_KEY_GROUP)
                     self._context.token_range = Range(
                         Position(
                             line=self._context.target_position.line,

--- a/server/services/language.py
+++ b/server/services/language.py
@@ -8,7 +8,6 @@ from pygls.workspace import Document
 from pygls.types import (
     CompletionList,
     CompletionParams,
-    CompletionTriggerKind,
     Diagnostic,
     DocumentFormattingParams,
     Hover,
@@ -54,13 +53,8 @@ class GalaxyToolLanguageService:
 
     def get_completion(self, document: Document, params: CompletionParams) -> CompletionList:
         """Gets completion items depending on the current document context."""
-        triggerKind = params.context.triggerKind
-        if triggerKind == CompletionTriggerKind.TriggerCharacter:
-            context = self.xml_context_service.get_xml_context(document, params.position)
-            if params.context.triggerCharacter == "<":
-                return self.completion_service.get_node_completion(context)
-            if params.context.triggerCharacter == " ":
-                return self.completion_service.get_attribute_completion(context)
+        context = self.xml_context_service.get_xml_context(document, params.position)
+        return self.completion_service.get_completion_at_context(context, params.context)
 
     def get_auto_close_tag(
         self, document: Document, params: TextDocumentPositionParams

--- a/server/tests/unit/test_xsd_parser.py
+++ b/server/tests/unit/test_xsd_parser.py
@@ -239,3 +239,13 @@ class TestXsdParserClass:
         doc = tree.root.get_doc("de")
 
         assert doc.value == MSG_NO_DOCUMENTATION_AVAILABLE
+
+    def test_parser_returns_expected_enumeration_restrictions(
+        self, xsd_parser,
+    ):
+        tree = xsd_parser.get_tree()
+
+        attribute_with_restriction = tree.root.attributes["value"]
+        actual = attribute_with_restriction.enumeration
+
+        assert actual == ["v1", "v2", "v3"]

--- a/server/tests/unit/test_xsd_parser.py
+++ b/server/tests/unit/test_xsd_parser.py
@@ -1,5 +1,6 @@
 import pytest
 
+from typing import List
 from lxml import etree
 from ...services.xsd.parser import GalaxyToolXsdParser
 from ...services.xsd.constants import MSG_NO_DOCUMENTATION_AVAILABLE
@@ -133,7 +134,7 @@ def recursive_xsd_parser() -> GalaxyToolXsdParser:
 
 
 class TestXsdParserClass:
-    def test_get_tree_returns_valid_element_names(self, xsd_parser):
+    def test_get_tree_returns_valid_element_names(self, xsd_parser: GalaxyToolXsdParser) -> None:
         tree = xsd_parser.get_tree()
         root = tree.root
 
@@ -154,7 +155,9 @@ class TestXsdParserClass:
         assert root.children[3].children[0].name == "group_elem1"
         assert root.children[3].children[1].name == "group_elem2"
 
-    def test_get_tree_returns_valid_attribute_names_using_groups(self, xsd_parser):
+    def test_get_tree_returns_valid_attribute_names_using_groups(
+        self, xsd_parser: GalaxyToolXsdParser
+    ) -> None:
         tree = xsd_parser.get_tree()
         root = tree.root
 
@@ -164,26 +167,34 @@ class TestXsdParserClass:
         assert root.attributes["gattr1"]
         assert root.attributes["gattr2"]
 
-    def test_get_tree_returns_valid_attribute_names_when_simple_content(self, xsd_parser):
+    def test_get_tree_returns_valid_attribute_names_when_simple_content(
+        self, xsd_parser: GalaxyToolXsdParser
+    ) -> None:
         tree = xsd_parser.get_tree()
         simple_content_elem = tree.root.children[2].children[0]
 
         assert len(simple_content_elem.attributes) == 1
         assert simple_content_elem.attributes["simple"]
 
-    def test_get_tree_returns_valid_element_when_complex_content(self, xsd_parser):
+    def test_get_tree_returns_valid_element_when_complex_content(
+        self, xsd_parser: GalaxyToolXsdParser
+    ) -> None:
         tree = xsd_parser.get_tree()
         complex_content_elem = tree.root.children[2].children[0]
 
         assert len(complex_content_elem.attributes) == 1
         assert complex_content_elem.attributes["simple"]
 
-    def test_get_tree_with_recursive_xsd_stops_recursion(self, recursive_xsd_parser):
+    def test_get_tree_with_recursive_xsd_stops_recursion(
+        self, recursive_xsd_parser: GalaxyToolXsdParser
+    ) -> None:
         tree = recursive_xsd_parser.get_tree()
 
         assert len(tree.root.descendants) > 0
 
-    def test_tree_find_node_by_name_returns_expected_node(self, xsd_parser):
+    def test_tree_find_node_by_name_returns_expected_node(
+        self, xsd_parser: GalaxyToolXsdParser
+    ) -> None:
         tree = xsd_parser.get_tree()
         expected = "childElement"
 
@@ -201,7 +212,9 @@ class TestXsdParserClass:
             (["testElement", "element_with_group", "group_elem1"], "group_elem1",),
         ],
     )
-    def test_tree_find_node_by_stack_returns_expected_node(self, xsd_parser, stack, expected):
+    def test_tree_find_node_by_stack_returns_expected_node(
+        self, xsd_parser: GalaxyToolXsdParser, stack: List[str], expected: str
+    ) -> None:
         tree = xsd_parser.get_tree()
 
         node = tree.find_node_by_stack(stack)
@@ -209,22 +222,26 @@ class TestXsdParserClass:
         assert node.name == expected
 
     def test_tree_find_node_by_name_returns_None_when_node_not_found(
-        self, xsd_parser,
-    ):
+        self, xsd_parser: GalaxyToolXsdParser
+    ) -> None:
         tree = xsd_parser.get_tree()
 
         node = tree.find_node_by_name("unknown")
 
         assert node is None
 
-    def test_get_documentation_returns_valid_when_exists(self, xsd_parser):
+    def test_get_documentation_returns_valid_when_exists(
+        self, xsd_parser: GalaxyToolXsdParser
+    ) -> None:
         tree = xsd_parser.get_tree()
 
         doc = tree.root.get_doc()
 
         assert doc.value == "Documentation ``example``."
 
-    def test_get_documentation_returns_valid_other_language(self, xsd_parser):
+    def test_get_documentation_returns_valid_other_language(
+        self, xsd_parser: GalaxyToolXsdParser
+    ) -> None:
         tree = xsd_parser.get_tree()
 
         doc = tree.root.get_doc("es")
@@ -232,8 +249,8 @@ class TestXsdParserClass:
         assert doc.value == "``Ejemplo`` de documentación."
 
     def test_get_documentation_should_return_no_documentation_when_not_exists(
-        self, xsd_parser,
-    ):
+        self, xsd_parser: GalaxyToolXsdParser
+    ) -> None:
         tree = xsd_parser.get_tree()
 
         doc = tree.root.get_doc("de")
@@ -241,8 +258,8 @@ class TestXsdParserClass:
         assert doc.value == MSG_NO_DOCUMENTATION_AVAILABLE
 
     def test_parser_returns_expected_enumeration_restrictions(
-        self, xsd_parser,
-    ):
+        self, xsd_parser: GalaxyToolXsdParser
+    ) -> None:
         tree = xsd_parser.get_tree()
 
         attribute_with_restriction = tree.root.attributes["value"]


### PR DESCRIPTION
When an attribute defined in the XSD contains enumeration restrictions, the values of the enumeration are used to auto-complete the attribute.
Right now you can trigger the value auto-completion when the cursor is inside the attribute value and you invoke the completion command by pressing ``ctrl+space``.

![enumrestriction](https://user-images.githubusercontent.com/46503462/93806577-a0465f00-fc49-11ea-88e1-40161e9dcebd.gif)
