### PR TITLE
Fix CDATA context

### DIFF
--- a/server/services/context.py
+++ b/server/services/context.py
@@ -10,6 +10,8 @@ import re
 from .xsd.types import XsdTree, XsdNode
 
 
+CDATA_BLOCK_START_SIZE = len("<![CDATA[")
+CDATA_BLOCK_END_SIZE = len("]]>")
 START_TAG_REGEX = r"<([a-z_]+)[ \n\W]?"
 ATTR_KEY_VALUE_REGEX = r" ([a-z_]*)=\"([\w. ]*)[\"]?"
 TAG_GROUP = 1
@@ -20,8 +22,6 @@ SUPPORTED_RECOVERY_EXCEPTIONS = [
     "no element found",
     "not well-formed (invalid token)",
 ]
-CDATA_BLOCK_START_SIZE = len("<![CDATA[")
-CDATA_BLOCK_END_SIZE = len("]]>")
 
 
 @unique

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -18,17 +18,21 @@ FAKE_CONTENT = """
 <tool id="test">
     <description/>
     <test value="0"/>
+    <help><![CDATA[
+        Sample text
+    ]]></help>
+    <inputs></inputs>
 </tool>'
 """
 FAKE_DOC_URI = "file://fake_doc.xml"
 FAKE_DOCUMENT = Document(FAKE_DOC_URI, FAKE_CONTENT)
 
 
-def get_fake_document(content: str):
+def get_fake_document(content: str) -> Document:
     return Document(FAKE_DOC_URI, content)
 
 
-def print_context_params(document: Document, position: Position):
+def print_context_params(document: Document, position: Position) -> None:
     print(f"Test context at position [line={position.line}, char={position.character}]")
     print(f"Document:\n{document.source}")
 
@@ -444,6 +448,10 @@ class TestXmlContextParserClass:
                 Position(line=0, character=26),
                 ["first", "third"],
             ),
+            (FAKE_DOCUMENT, Position(line=4, character=10), ["tool", "help"]),
+            (FAKE_DOCUMENT, Position(line=4, character=18), ["tool", "help"]),
+            (FAKE_DOCUMENT, Position(line=6, character=5), ["tool", "help"]),
+            (FAKE_DOCUMENT, Position(line=6, character=7), ["tool", "help"]),
         ],
     )
     def test_parse_return_expected_tag_stack_context(
@@ -601,6 +609,10 @@ class TestXmlContextParserClass:
                 Position(line=1, character=30),
                 False,
             ),
+            (FAKE_DOCUMENT, Position(line=4, character=10), True),
+            (FAKE_DOCUMENT, Position(line=4, character=18), True),
+            (FAKE_DOCUMENT, Position(line=6, character=5), True),
+            (FAKE_DOCUMENT, Position(line=6, character=7), True),
         ],
     )
     def test_parse_returns_context_with_expected_is_node_content(


### PR DESCRIPTION
When the cursor was positioned on an opening or closing CDATA block, the context parser should stop and classify the context as ``content``. Before this fix, the parser will skip the CDATA annotation and continue parsing beyond the target position. This could result in invalid node stacks resolution when the context is positioned exactly over these CDATA elements.

To detect when the cursor is on the CDATA block, [these methods](https://github.com/davelopez/galaxy-tools-extension/compare/fix-cdata-context?expand=1#diff-fc334655ded569ca2404b0b758a8d677R247-R255) were added. The rest of the _empty_ methods must be declared to implement the LexicalHandler for SAX defined [here](https://github.com/davelopez/galaxy-tools-extension/compare/fix-cdata-context?expand=1#diff-fc334655ded569ca2404b0b758a8d677R159).

Additional tests were added to verify the fix.