### PR TITLE
Improve attribute completion

### DIFF
--- a/server/services/completion.py
+++ b/server/services/completion.py
@@ -85,7 +85,7 @@ class XmlCompletionService:
         if context.node:
             for attr_name in context.node.attributes:
                 attr = context.node.attributes[attr_name]
-                result.append(self._build_attribute_completion_item(attr))
+                result.append(self._build_attribute_completion_item(attr, len(result)))
         return CompletionList(items=result, is_incomplete=False)
 
     def get_attribute_value_completion(self, context: XmlContext) -> CompletionList:
@@ -144,7 +144,7 @@ class XmlCompletionService:
         """
         return CompletionItem(node.name, CompletionItemKind.Class, documentation=node.get_doc(),)
 
-    def _build_attribute_completion_item(self, attr: XsdAttribute) -> CompletionItem:
+    def _build_attribute_completion_item(self, attr: XsdAttribute, order:int) -> CompletionItem:
         """Generates a completion item with the information about the
         given attribute definition.
 
@@ -162,4 +162,5 @@ class XmlCompletionService:
             documentation=attr.get_doc(),
             insert_text=f'{attr.name}="$1"',
             insert_text_format=InsertTextFormat.Snippet,
+            sort_text=str(order)
         )

--- a/server/services/completion.py
+++ b/server/services/completion.py
@@ -84,6 +84,8 @@ class XmlCompletionService:
         result = []
         if context.node:
             for attr_name in context.node.attributes:
+                if attr_name in context.attr_list:
+                    continue
                 attr = context.node.attributes[attr_name]
                 result.append(self._build_attribute_completion_item(attr, len(result)))
         return CompletionList(items=result, is_incomplete=False)

--- a/server/services/completion.py
+++ b/server/services/completion.py
@@ -146,7 +146,7 @@ class XmlCompletionService:
         """
         return CompletionItem(node.name, CompletionItemKind.Class, documentation=node.get_doc(),)
 
-    def _build_attribute_completion_item(self, attr: XsdAttribute, order:int) -> CompletionItem:
+    def _build_attribute_completion_item(self, attr: XsdAttribute, order: int) -> CompletionItem:
         """Generates a completion item with the information about the
         given attribute definition.
 
@@ -164,5 +164,5 @@ class XmlCompletionService:
             documentation=attr.get_doc(),
             insert_text=f'{attr.name}="$1"',
             insert_text_format=InsertTextFormat.Snippet,
-            sort_text=str(order).zfill(2)
+            sort_text=str(order).zfill(2),
         )

--- a/server/services/completion.py
+++ b/server/services/completion.py
@@ -162,5 +162,5 @@ class XmlCompletionService:
             documentation=attr.get_doc(),
             insert_text=f'{attr.name}="$1"',
             insert_text_format=InsertTextFormat.Snippet,
-            sort_text=str(order)
+            sort_text=str(order).zfill(2)
         )

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -57,6 +57,7 @@ class XmlContext:
         self.token_type = token_type
         self.token_range: Range = None
         self.attr_name = None
+        self.attr_list: List[str] = []
         self.node: Optional[XsdNode] = None
         self.is_node_content: bool = False
         self.node_stack: List[str] = []
@@ -276,6 +277,7 @@ class ContextBuilderHandler(xml.sax.ContentHandler):
         return False
 
     def _build_context_from_element_line(self, start_position: int, tag: str, attributes):
+        self._context.attr_list = list(attributes.keys())
         target_offset = self._context.target_position.character
         tag_offset = start_position + len(tag)
         is_on_tag = start_position <= target_offset <= tag_offset
@@ -395,6 +397,7 @@ class ContextParseErrorHandler(xml.sax.ErrorHandler):
             ATTR_KEY_VALUE_REGEX, self._context.document_line, re.DOTALL
         )
         if attribute_matches:
+            self._context.attr_list = [match.group(ATTR_KEY_GROUP) for match in attribute_matches]
             for match in attribute_matches:
                 if match.start(ATTR_KEY_GROUP) <= target_offset <= match.end(ATTR_KEY_GROUP):
                     self._context.token_type = ContextTokenType.ATTRIBUTE_KEY

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -340,8 +340,8 @@ class ContextParseErrorHandler(xml.sax.ErrorHandler):
 
     def _try_recover_context_from_exception(self, start_offset: int) -> None:
         target_offset = self._context.target_position.character
-        self._try_get_tag_context_at_line_position(target_offset)
         self._try_get_attribute_context_at_line_position(target_offset)
+        self._try_get_tag_context_at_line_position(target_offset)
 
     def _try_get_tag_context_at_line_position(self, target_offset: int) -> None:
         tag_matches = re.finditer(START_TAG_REGEX, self._context.document_line, re.DOTALL)
@@ -397,6 +397,7 @@ class ContextParseErrorHandler(xml.sax.ErrorHandler):
         )
         self._context.attr_list = []
         for match in attribute_matches:
+            self._context.attr_list.append(match.group(ATTR_KEY_GROUP))
             if match.start(ATTR_KEY_GROUP) <= target_offset <= match.end(ATTR_KEY_GROUP):
                 self._context.token_type = ContextTokenType.ATTRIBUTE_KEY
                 self._context.token_name = match.group(ATTR_KEY_GROUP)
@@ -411,9 +412,7 @@ class ContextParseErrorHandler(xml.sax.ErrorHandler):
                     ),
                 )
                 raise ContextFoundException()
-            else:
-                self._context.attr_list.append(match.group(ATTR_KEY_GROUP))
-            
+
             if match.start(ATTR_VALUE_GROUP) <= target_offset <= match.end(ATTR_VALUE_GROUP):
                 self._context.token_type = ContextTokenType.ATTRIBUTE_VALUE
                 self._context.token_name = match.group(ATTR_VALUE_GROUP)
@@ -429,7 +428,7 @@ class ContextParseErrorHandler(xml.sax.ErrorHandler):
                     ),
                 )
                 raise ContextFoundException()
-            
+
 
 class ContextFoundException(Exception):
     """When this exception is raised, it indicates that the necessary

--- a/server/tests/unit/test_completion.py
+++ b/server/tests/unit/test_completion.py
@@ -27,6 +27,19 @@ def fake_tree(mocker: MockerFixture) -> XsdTree:
 
 
 @pytest.fixture()
+def fake_tree_with_attrs(mocker: MockerFixture) -> XsdTree:
+    fake_root = XsdNode("root", element=mocker.Mock())
+    fake_attr = XsdAttribute("one", element=mocker.Mock())
+    fake_root.attributes[fake_attr.name] = fake_attr
+    fake_attr = XsdAttribute("two", element=mocker.Mock())
+    fake_root.attributes[fake_attr.name] = fake_attr
+    fake_attr = XsdAttribute("three", element=mocker.Mock())
+    fake_root.attributes[fake_attr.name] = fake_attr
+    XsdNode("child", element=mocker.Mock(), parent=fake_root)
+    return XsdTree(fake_root)
+
+
+@pytest.fixture()
 def fake_empty_context(fake_tree: XsdTree) -> XmlContext:
     fake_root = fake_tree.root
     fake_context = XmlContext(is_empty=True)
@@ -109,6 +122,28 @@ class TestXmlCompletionServiceClass:
         assert len(actual.items) == 1
         assert actual.items[0].label == "attr"
         assert actual.items[0].kind == CompletionItemKind.Variable
+
+    def test_get_completion_at_context_on_node_with_attribute_returns_expected_attributes(
+        self, fake_tree_with_attrs: XsdTree
+    ) -> None:
+        fake_context = XmlContext()
+        fake_context.is_empty = False
+        fake_context.attr_list = ["one"]
+        fake_context.token_type = ContextTokenType.UNKNOWN
+        fake_context.node = fake_tree_with_attrs.root
+        fake_completion_context = CompletionContext(
+            CompletionTriggerKind.TriggerCharacter, trigger_character=" "
+        )
+        service = XmlCompletionService(fake_tree_with_attrs)
+
+        actual = service.get_completion_at_context(fake_context, fake_completion_context)
+
+        assert actual
+        assert len(actual.items) == 2
+        assert actual.items[0].label == "two"
+        assert actual.items[0].kind == CompletionItemKind.Variable
+        assert actual.items[1].label == "three"
+        assert actual.items[1].kind == CompletionItemKind.Variable
 
     def test_get_completion_at_context_on_attr_value_returns_expected_enums(
         self, fake_tree: XsdTree


### PR DESCRIPTION
This PR closes #26 by introducing the following improvements during attribute auto-completion:
- The attributes are now displayed in the same order as they are defined in the XSD instead of alphabetical order.
- If an attribute is already defined in the document, this attribute is no longer suggested by the auto-completion.

![impr attr completion](https://user-images.githubusercontent.com/46503462/94367224-9c00c280-00dd-11eb-875e-06ec5e151421.gif)

Some tests added for this functionality.