### PR TITLE
Fix auto-close when tag mistmatched

### DIFF
--- a/server/services/completion.py
+++ b/server/services/completion.py
@@ -50,9 +50,6 @@ class XmlCompletionService:
             CompletionList: A list of completion items with the child nodes
             that can be placed under the current node.
         """
-        if context.is_invalid:
-            return CompletionList(is_incomplete=False)
-
         result = []
         if context.is_empty:
             result.append(self._build_node_completion_item(context.node))
@@ -73,12 +70,7 @@ class XmlCompletionService:
             CompletionList: The completion item with the basic information
             about the attributes.
         """
-        if (
-            context.is_empty
-            or context.is_invalid
-            or context.is_node_content
-            or context.is_attribute_value()
-        ):
+        if context.is_empty or context.is_node_content or context.is_attribute_value():
             return CompletionList(is_incomplete=False)
 
         result = []
@@ -125,7 +117,7 @@ class XmlCompletionService:
             replace_range = Range(start=start, end=end)
             if not context.is_node_content:
                 snippet = "/>$0"
-        elif context.is_node_content or context.is_invalid:
+        elif context.is_node_content:
             return None
 
         return AutoCloseTagResult(snippet, replace_range)

--- a/server/services/context.py
+++ b/server/services/context.py
@@ -22,6 +22,7 @@ SUPPORTED_RECOVERY_EXCEPTIONS = [
     "unclosed token",
     "no element found",
     "not well-formed (invalid token)",
+    "mismatched tag",
 ]
 
 

--- a/server/tests/unit/test_completion.py
+++ b/server/tests/unit/test_completion.py
@@ -35,15 +35,6 @@ def fake_empty_context(fake_tree: XsdTree) -> XmlContext:
 
 
 @pytest.fixture()
-def fake_invalid_context(fake_tree: XsdTree) -> XmlContext:
-    fake_root = fake_tree.root
-    fake_context = XmlContext()
-    fake_context.is_invalid = True
-    fake_context.node = fake_root
-    return fake_context
-
-
-@pytest.fixture()
 def fake_context_on_root_node(fake_tree: XsdTree) -> XmlContext:
     fake_root = fake_tree.root
     fake_context = XmlContext()
@@ -149,15 +140,6 @@ class TestXmlCompletionServiceClass:
 
         assert len(actual.items) == 1
         assert actual.items[0].label == fake_tree.root.name
-
-    def test_returns_empty_completion_when_invalid_context(
-        self, fake_tree: XsdTree, fake_invalid_context
-    ) -> None:
-        service = XmlCompletionService(fake_tree)
-
-        actual = service.get_node_completion(fake_invalid_context)
-
-        assert len(actual.items) == 0
 
     def test_return_empty_attribute_completion_when_empty_context(
         self, fake_tree: XsdTree, fake_empty_context

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -479,7 +479,6 @@ class TestXmlContextParserClass:
         context = parser.parse(document, position)
 
         assert context.node_stack == expected
-        assert not context.is_invalid
 
     @pytest.mark.parametrize(
         "document, position, expected",
@@ -641,12 +640,3 @@ class TestXmlContextParserClass:
         context = parser.parse(document, position)
 
         assert context.is_node_content == expected
-
-    def test_parse_returns_invalid_context_when_invalid_content(self) -> None:
-        document = get_fake_document("Invalid xml")
-        position = Position(line=0, character=4)
-        parser = XmlContextParser()
-
-        context = parser.parse(document, position)
-
-        assert context.is_invalid

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -459,6 +459,11 @@ class TestXmlContextParserClass:
                 Position(line=0, character=26),
                 ["first", "third"],
             ),
+            (
+                get_fake_document("<first>\n    <second>  \n</first>"),
+                Position(line=1, character=11),
+                ["first", "second"],
+            ),
             (FAKE_DOCUMENT, Position(line=4, character=10), ["tool", "help"]),
             (FAKE_DOCUMENT, Position(line=4, character=18), ["tool", "help"]),
             (FAKE_DOCUMENT, Position(line=6, character=5), ["tool", "help"]),
@@ -474,6 +479,7 @@ class TestXmlContextParserClass:
         context = parser.parse(document, position)
 
         assert context.node_stack == expected
+        assert not context.is_invalid
 
     @pytest.mark.parametrize(
         "document, position, expected",


### PR DESCRIPTION
When trying to auto-close a tag in the middle of a file where there is a tag mismatch, the context was invalid and the auto-completion failed.
This PR adds the ``mismatched tag`` case to the supported recovery exceptions.
