### PR TITLE
Fix completion on closing tag

### DIFF
--- a/server/services/completion.py
+++ b/server/services/completion.py
@@ -70,7 +70,12 @@ class XmlCompletionService:
             CompletionList: The completion item with the basic information
             about the attributes.
         """
-        if context.is_empty or context.is_node_content or context.is_attribute_value():
+        if (
+            context.is_empty
+            or context.is_node_content
+            or context.is_attribute_value()
+            or context.is_closing_tag
+        ):
             return CompletionList(is_incomplete=False)
 
         result = []

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -686,3 +686,26 @@ class TestXmlContextParserClass:
         context = parser.parse(document, position)
 
         assert context.attr_list == expected
+
+    @pytest.mark.parametrize(
+        "document, position, expected",
+        [
+            (get_fake_document("<first> </first>"), Position(line=0, character=7), False,),
+            (get_fake_document("<first></first>"), Position(line=0, character=8), True,),
+            (get_fake_document("<first></first>"), Position(line=0, character=14), True,),
+            (get_fake_document("<first></first >"), Position(line=0, character=14), True,),
+            (get_fake_document("<first></first"), Position(line=0, character=10), True,),
+            (get_fake_document("<first/>"), Position(line=0, character=7), True,),
+            (get_fake_document("<first/ >"), Position(line=0, character=7), True,),
+        ],
+    )
+    def test_parse_return_expected_is_closin_tag(
+        self, document: Document, position: Position, expected: bool
+    ) -> None:
+        print_context_params(document, position)
+        parser = XmlContextParser()
+
+        context = parser.parse(document, position)
+
+        assert context.is_closing_tag == expected
+

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -697,6 +697,9 @@ class TestXmlContextParserClass:
             (get_fake_document("<first></first"), Position(line=0, character=10), True,),
             (get_fake_document("<first/>"), Position(line=0, character=7), True,),
             (get_fake_document("<first/ >"), Position(line=0, character=7), True,),
+            (get_fake_document('<first attr="1"/>'), Position(line=0, character=15), False,),
+            (get_fake_document('<first attr="1" />'), Position(line=0, character=15), False,),
+            (get_fake_document('<first attr="1"/'), Position(line=0, character=15), False,),
         ],
     )
     def test_parse_return_expected_is_closin_tag(
@@ -708,4 +711,3 @@ class TestXmlContextParserClass:
         context = parser.parse(document, position)
 
         assert context.is_closing_tag == expected
-

--- a/server/tests/unit/test_context.py
+++ b/server/tests/unit/test_context.py
@@ -357,7 +357,7 @@ class TestXmlContextParserClass:
             (
                 get_fake_document('<first id="value"><second/></first'),
                 Position(line=0, character=29),
-                ContextTokenType.UNKNOWN,
+                ContextTokenType.TAG,
             ),
         ],
     )


### PR DESCRIPTION
There was an unwanted behaviour when typing a space inside a closing or self-closing tag that would trigger the current node attribute autocompletion.
![bug attr close](https://user-images.githubusercontent.com/46503462/94605205-10cc2c00-0299-11eb-881b-2b9690d60568.gif)

This PR fixes this bug detecting when the context is inside a closing tag and, in that case, ignoring the attribute completion.
![fix attr close](https://user-images.githubusercontent.com/46503462/94605218-175aa380-0299-11eb-9c0c-725d8082112b.gif)
