### PR TITLE
Improve tag ordering on suggestions

### DIFF
--- a/server/services/completion.py
+++ b/server/services/completion.py
@@ -55,7 +55,7 @@ class XmlCompletionService:
             result.append(self._build_node_completion_item(context.node))
         elif context.node:
             for child in context.node.children:
-                result.append(self._build_node_completion_item(child))
+                result.append(self._build_node_completion_item(child, len(result)))
         return CompletionList(items=result, is_incomplete=False)
 
     def get_attribute_completion(self, context: XmlContext) -> CompletionList:
@@ -129,27 +129,36 @@ class XmlCompletionService:
 
         return AutoCloseTagResult(snippet, replace_range)
 
-    def _build_node_completion_item(self, node: XsdNode) -> CompletionItem:
+    def _build_node_completion_item(self, node: XsdNode, order: int = 0) -> CompletionItem:
         """Generates a completion item with the information about the
         given node definition.
 
         Args:
             node (XsdNode): The node definition used to build the
             completion item.
+            order (int): The position for ordering this item.
 
         Returns:
             CompletionItem: The completion item with the basic information
             about the node.
         """
-        return CompletionItem(node.name, CompletionItemKind.Class, documentation=node.get_doc(),)
+        return CompletionItem(
+            node.name,
+            CompletionItemKind.Class,
+            documentation=node.get_doc(),
+            sort_text=str(order).zfill(2),
+        )
 
-    def _build_attribute_completion_item(self, attr: XsdAttribute, order: int) -> CompletionItem:
+    def _build_attribute_completion_item(
+        self, attr: XsdAttribute, order: int = 0
+    ) -> CompletionItem:
         """Generates a completion item with the information about the
         given attribute definition.
 
         Args:
             attr (XsdAttribute): The attribute definition used to build the
             completion item.
+            order (int): The position for ordering this item.
 
         Returns:
             CompletionItem: The completion item with the basic information

--- a/server/services/xsd/parser.py
+++ b/server/services/xsd/parser.py
@@ -99,6 +99,10 @@ class GalaxyToolXsdParser:
                 self._apply_named_type_to_node(element_type_name, node, depth + 1)
                 # minOccurs defaults to 1
                 node.min_occurs = int(element.attrib.get("minOccurs", 1))
+                max_occurs = element.attrib.get("maxOccurs", -1)
+                if max_occurs == "unbounded":
+                    max_occurs = -1
+                node.max_occurs = int(max_occurs)
                 self._build_tree_recursive(element, node, depth + 1)
             elif tag == XS_COMPLEX_TYPE:
                 if not element_name:

--- a/server/tests/unit/test_xsd_parser.py
+++ b/server/tests/unit/test_xsd_parser.py
@@ -6,7 +6,7 @@ from ...services.xsd.parser import GalaxyToolXsdParser
 from ...services.xsd.constants import MSG_NO_DOCUMENTATION_AVAILABLE
 
 TEST_XSD = """<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <xs:element name="testElement" type="CustomComplexType">
+  <xs:element name="testElement" type="CustomComplexType" minOccurs="1" maxOccurs="1">
     <xs:annotation>
       <xs:documentation xml:lang="en">
         <![CDATA[Documentation ``example``.]]>
@@ -18,7 +18,7 @@ TEST_XSD = """<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   </xs:element>
   <xs:complexType name="CustomComplexType">
     <xs:sequence>
-      <xs:element name="firstElement" type="CustomIntSimpleType">
+      <xs:element name="firstElement" type="CustomIntSimpleType" minOccurs="0" maxOccurs="unbounded">
         <xs:annotation>
           <xs:documentation xml:lang="en">
             <![CDATA[
@@ -266,3 +266,23 @@ class TestXsdParserClass:
         actual = attribute_with_restriction.enumeration
 
         assert actual == ["v1", "v2", "v3"]
+
+    def test_parser_returns_expected_occurs_restrictions(
+        self, xsd_parser: GalaxyToolXsdParser
+    ) -> None:
+        tree = xsd_parser.get_tree()
+
+        actual = tree.root
+
+        assert actual.min_occurs == 1
+        assert actual.max_occurs == 1
+
+    def test_parser_returns_expected_occurs_when_unbounded(
+        self, xsd_parser: GalaxyToolXsdParser
+    ) -> None:
+        tree = xsd_parser.get_tree()
+
+        actual = tree.root.children[0]
+
+        assert actual.min_occurs == 0
+        assert actual.max_occurs == -1


### PR DESCRIPTION
As defined in #29, this PR displays the suggested tags in the same order that they appear in the [Galaxy.xsd](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/xsd/galaxy.xsd) instead of the default alphabetical order. This helps to maintain the recommended order of tags as in the [Galaxy IUC Coding Style](https://galaxy-iuc-standards.readthedocs.io/en/latest/best_practices/tool_xml.html?#coding-style) without the need to maintain an additional list just for the ordering. Currently, the XSD should be updated in a future version to declare the elements in the same order described in the guidelines. 